### PR TITLE
Update readme to modify the right kubeconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ gcloud compute scp kubeadm-single-node-cluster:/etc/kubernetes/admin.conf \
 
 > It may take a few minutes for the cluster to finish bootstrapping and the client config to become readable.
 
+Set the `KUBECONFIG` env var to point to the `kubeadm-single-node-cluster.conf` kubeconfig:
+
+```
+export KUBECONFIG=$(PWD)/kubeadm-single-node-cluster.conf
+```
+
 Set the `kubeadm-single-node-cluster` kubeconfig server address to the public IP address:
 
 ```
@@ -42,12 +48,6 @@ kubectl config set-cluster kubernetes \
   --kubeconfig kubeadm-single-node-cluster.conf \
   --server https://$(gcloud compute instances describe kubeadm-single-node-cluster \
      --format='value(networkInterfaces.accessConfigs[0].natIP)'):6443
-```
-
-Set the `KUBECONFIG` env var to point to the `kubeadm-single-node-cluster.conf` kubeconfig:
-
-```
-export KUBECONFIG=$(PWD)/kubeadm-single-node-cluster.conf
 ```
 
 ## Verification


### PR DESCRIPTION
Otherwise it attempts to modify the default kubeconfig in $HOME/.kube, if we move the instructions up, `kubectl config set-cluster` will update the right config file. 

Without this change, the instructions listed do not work.