### PR TITLE
use ${PWD} instead of $(PWD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gcloud compute scp kubeadm-single-node-cluster:/etc/kubernetes/admin.conf \
 Set the `KUBECONFIG` env var to point to the `kubeadm-single-node-cluster.conf` kubeconfig:
 
 ```
-export KUBECONFIG=$(PWD)/kubeadm-single-node-cluster.conf
+export KUBECONFIG=${PWD}/kubeadm-single-node-cluster.conf
 ```
 
 Set the `kubeadm-single-node-cluster` kubeconfig server address to the public IP address:


### PR DESCRIPTION
for modern bash it's safe to use $(pwd) or ${PWD}
$(PWD) usage gives an error

$ export KUBECONFIG=$(PWD)/kubeadm-single-node-cluster.conf
PWD: command not found

GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)