### PR TITLE
Add [Service] section to 20-cloud-provider.conf

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -18,6 +18,7 @@ sudo apt-get install -y kubelet kubeadm
 sudo systemctl enable docker.service
 
 cat <<EOF > 20-cloud-provider.conf
+[Service]
 Environment="KUBELET_EXTRA_ARGS=--cloud-provider=gce"
 EOF
 


### PR DESCRIPTION
Add `[Service]` section to 20-cloud-provider.conf to ensure kubelet gets cloud provider configured.

Without this things like storage classes and persistent volume claims do not work.