### PR TITLE
Bump Kubernetes to v1.10, Calico to version v3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Create a single compute instance:
 ```bash
 gcloud compute instances create kubeadm-single-node-cluster \
   --can-ip-forward \
-  --image-family ubuntu-1704 \
+  --image-family ubuntu-1804-lts \
   --image-project ubuntu-os-cloud \
   --machine-type n1-standard-4 \
-  --metadata kubernetes-version=stable-1.8 \
+  --metadata kubernetes-version=stable-1.10 \
   --metadata-from-file startup-script=startup.sh \
   --tags kubeadm-single-node-cluster \
   --scopes cloud-platform,logging-write
@@ -72,8 +72,8 @@ Find out Kubernetes API server version:
 kubectl version --short
 ```
 ```
-Client Version: v1.8.0
-Server Version: v1.8.0
+Client Version: v1.10.3
+Server Version: v1.10.3
 ```
 
 Create a nginx deployment:

--- a/startup.sh
+++ b/startup.sh
@@ -40,22 +40,20 @@ apiServerCertSANs:
   - ${EXTERNAL_IP}
   - ${INTERNAL_IP}
 apiServerExtraArgs:
-  admission-control: PodPreset,Initializers,GenericAdmissionWebhook,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
+  admission-control: NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
   feature-gates: AllAlpha=true
   runtime-config: api/all
 cloudProvider: gce
 kubernetesVersion: ${KUBERNETES_VERSION}
 networking:
   podSubnet: 192.168.0.0/16
+noTaintMaster: true
 EOF
 
 sudo kubeadm init --config=kubeadm.conf
 
 sudo chmod 644 /etc/kubernetes/admin.conf
 
-kubectl taint nodes --all node-role.kubernetes.io/master- \
-  --kubeconfig /etc/kubernetes/admin.conf
-
 kubectl apply \
-  -f http://docs.projectcalico.org/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml \
+  -f https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml \
   --kubeconfig /etc/kubernetes/admin.conf


### PR DESCRIPTION
Handfull of updates to make the script play nicely with Kubernetes v1.10:

 - Bumps the K8S version in the README.

 - Updates to latest Ubuntu LTS (image from the original script no longer
   exists).

 - Updates the admission-control passed to the API server to v1.10 recommended
   defaults.

 - Takes advantage of native support in kubeadm to not taint the master node.

 - Grabs the latest Calico recommended in the kubeadm docs.